### PR TITLE
Update newsletter page

### DIFF
--- a/app/components/NewsletterCard.tsx
+++ b/app/components/NewsletterCard.tsx
@@ -28,10 +28,14 @@ export default function NewsletterCard({ campaign, locale }: NewsletterCardProps
   // Get preview URL or create a fallback
   const getNewsletterUrl = () => {
     if (primaryEmail?.preview_url) {
-      return primaryEmail.preview_url;
+      return primaryEmail.preview_url.replace("preview.mailerlite.com", "bareed.itqan.dev");
     }
     // Fallback to a generic newsletter view URL if preview is not available
-    return `https://preview.mailerlite.com/campaigns/${campaign.id}`;
+    return `https://bareed.itqan.dev/campaigns/${campaign.id}`;
+  };
+
+  const updateUrlWithBareedDomain = (url: string) => {
+    return url.replace("preview.mailerlite.io", "bareed.itqan.dev");
   };
 
   return (
@@ -40,10 +44,10 @@ export default function NewsletterCard({ campaign, locale }: NewsletterCardProps
         {/* Header */}
         <div className="mb-4">
           <h3 className="font-bold text-xl text-primary-900 mb-2 group-hover:text-primary-700 transition-colors">
-            {campaign.name}
+            {primaryEmail.subject}
           </h3>
           <p className="text-sm text-neutral-600">
-            {t("publishedOn")} {formatDate(campaign.finished_at || campaign.created_at)}
+            {campaign.name} {t("publishedOn")} {formatDate(campaign.created_at)}
           </p>
         </div>
 
@@ -58,9 +62,10 @@ export default function NewsletterCard({ campaign, locale }: NewsletterCardProps
 
 
         {/* Action button */}
+        {primaryEmail.preview_url && (
         <div className="mt-auto pt-4">
           <Link
-            href={getNewsletterUrl()}
+            href={updateUrlWithBareedDomain(primaryEmail.preview_url)}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 bg-primary-600 hover:bg-primary-700 text-white font-semibold px-4 py-2 rounded-lg transition-colors duration-200 hover-lift text-sm"
@@ -74,8 +79,9 @@ export default function NewsletterCard({ campaign, locale }: NewsletterCardProps
             >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6l6 6-6 6" />
             </svg>
-          </Link>
-        </div>
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/components/NewsletterCard.tsx
+++ b/app/components/NewsletterCard.tsx
@@ -43,19 +43,23 @@ export default function NewsletterCard({ campaign, locale }: NewsletterCardProps
       <div className="flex flex-col h-full">
         {/* Header */}
         <div className="mb-4">
-          <h3 className="font-bold text-xl text-primary-900 mb-2 group-hover:text-primary-700 transition-colors">
+          <h3 className="font-bold text-lg text-primary-900 mb-2 group-hover:text-primary-700 transition-colors">
             {primaryEmail.subject}
           </h3>
-          <p className="text-sm text-neutral-600">
+          <p className="text-xs text-neutral-600">
             {campaign.name} {t("publishedOn")} {formatDate(campaign.created_at)}
           </p>
         </div>
 
         {/* Subject line if available */}
         {primaryEmail?.subject && (
-          <div className="mb-4">
-            <p className="text-neutral-700 leading-relaxed line-clamp-2">
-              {primaryEmail.subject}
+          <div className="mt-auto mb-4">
+            <p className="text-neutral-700 leading-relaxed line-clamp-3">
+              {campaign.id === "163894378917528820"
+                ? "رحلة إتقان تبدأ من تحدي التطبيقات القرآنية.. قصص وأدوات تفتح آفاقًا جديدة للمطورين 🌍📱"
+                : campaign.id === "165600823697475277"
+                  ? "من ترتيل و”باحوث” إلى Quran Tab.. ابتكارات تضع التقنيات القرآنية في صدارة المشهد 🚀📖"
+                  : primaryEmail.preheader}
             </p>
           </div>
         )}
@@ -63,7 +67,7 @@ export default function NewsletterCard({ campaign, locale }: NewsletterCardProps
 
         {/* Action button */}
         {primaryEmail.preview_url && (
-        <div className="mt-auto pt-4">
+        <div className="">
           <Link
             href={updateUrlWithBareedDomain(primaryEmail.preview_url)}
             target="_blank"

--- a/app/utils/mailerlite.ts
+++ b/app/utils/mailerlite.ts
@@ -147,6 +147,7 @@ export interface MailerLiteEmail {
   };
   send_after: string | null;
   track_opens: boolean;
+  preheader: string;
 }
 
 export interface MailerLiteApiResponse<T> {

--- a/app/utils/mailerlite.ts
+++ b/app/utils/mailerlite.ts
@@ -213,6 +213,7 @@ export async function getCampaigns(
     'filter[status]': status,
     limit: limit.toString(),
     page: page.toString(),
+    sort: 'created_at',
   });
 
   if (type) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Newsletter links now open on bareed.itqan.dev, including fallback campaign URLs.
  * Titles use the email subject; subtext shows campaign name, localized “published” label, and created date.
  * Displays email preheader (or promotional copy for select campaigns).
  * Newsletter list is sorted by creation date.
  * Action button appears only when a preview is available.

* Style
  * Reduced header title size and adjusted spacing.
  * Increased subject line clamp from 2 to 3 lines.
  * Simplified button/link area layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->